### PR TITLE
In example, do not specify version tag, and provide example for .bash_profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ https://hub.docker.com/r/alpine/helm/tags/
 # Usage:
 
     # must mount the local folder to /apps in container.
-    docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube alpine/helm:2.9.1
+    docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube alpine/helm
 
     # run container as command
-    alias helm="docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube alpine/helm:2.9.1"
+    alias helm="docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube alpine/helm"
     helm --help
-
+    
+    # example in ~/.bash_profile
+    alias helm='docker run -e KUBECONFIG="/root/.kube/config:/root/.kube/some-other-context.yaml" -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube alpine/helm'
 
 # Why use it
 


### PR DESCRIPTION
* Copy-pasting the example will result in using an old version of helm and hard-to-debug errors
* Using single quotes is required if you add the add the alias to .bash_profile
* If you have several contexts, adding the KUBECONFIG environment variable to the container avoids the hard-to-debug error 'Error: could not get Kubernetes config for context "": invalid configuration: context was not found for specified context: some-other-context'