### PR TITLE
Adds mounting of ~/.helm into the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,28 +12,28 @@ Please avoid to use `latest` tag for any production deployment. Tag with right v
 
 https://github.com/alpine-docker/helm
 
-### Daily travis CI build logs
+### Daily Travis CI build logs
 
 https://travis-ci.org/alpine-docker/helm
 
-### Docker iamge tags
+### Docker image tags
 
 https://hub.docker.com/r/alpine/helm/tags/
 
 # Usage
 
     # must mount the local folder to /apps in container.
-    docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube alpine/helm
+    docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm alpine/helm
 
     # Run helm with special version. The tag is helm's version
-    docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube alpine/helm:2.12.1
+    docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm alpine/helm:2.12.1
 
     # run container as command
-    alias helm="docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube alpine/helm"
+    alias helm="docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm alpine/helm"
     helm --help
     
     # example in ~/.bash_profile
-    alias helm='docker run -e KUBECONFIG="/root/.kube/config:/root/.kube/some-other-context.yaml" -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube alpine/helm'
+    alias helm='docker run -e KUBECONFIG="/root/.kube/config:/root/.kube/some-other-context.yaml" -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm alpine/helm'
 
 # Why we need it
 


### PR DESCRIPTION
Actually allows using this helm image, by mounting a volume from ~/.helm into the container.

Without this additional mount, you simply cannot do:
helm init
helm repo add elastic https://helm.elastic.co

As the "init" is not persisted... 

Also fixed a couple of typos.