### PR TITLE
Feature/6 - bug fix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,45 +9,49 @@
 set -ex
 
 Usage() {
-  echo "$0 [rebuild]"
+  echo "$0"
 }
 
-image="alpine/helm"
-repo="helm/helm"
+build() {
+  BUILD_TAG=$1
 
-latest=`curl -sL -H "Authorization: token ${API_TOKEN}"  https://api.github.com/repos/${repo}/tags |jq -r ".[].name"|head -1|sed 's/^v//'`
-sum=0
-echo "Lastest release is: ${latest}"
-
-tags=`curl -sL https://hub.docker.com/v2/repositories/${image}/tags/ |jq -r .results[].name`
-
-for i in ${tags}
-do
-  if [ ${i} == ${latest} ];then
-    sum=$((sum+1))
-  fi
-done
-
-if [[ ( $sum -ne 1 ) || ( $1 == "rebuild" ) ]];then
-  docker build --no-cache --build-arg VERSION=$latest -t ${image}:${latest} .
+  docker build --no-cache --build-arg VERSION=${BUILD_TAG} -t ${image}:${BUILD_TAG} .
 
   # test
-  version=$(docker run -ti --rm ${image}:${latest} version )
+  version=$(docker run -ti --rm ${image}:${BUILD_TAG} version )
   #Client: &version.Version{SemVer:"v2.9.0-rc2", GitCommit:"08db2d0181f4ce394513c32ba1aee7ffc6bc3326", GitTreeState:"clean"}
-  version=$(echo $version| awk -F \" '{print $2}')
-  if [ "${version}" == "v${latest}" ]; then
+  version=$(echo ${version}| awk -F \" '{print $2}')
+  if [ "${version}" == "v${BUILD_TEST}" ]; then
     echo "matched"
   else
     echo "unmatched"
     exit
   fi
 
-  docker tag ${image}:${latest} ${image}:latest
-
   if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    docker push ${image}:${latest}
-    docker push ${image}:latest
+    docker push ${image}:${BUILD_TAG}
   fi
+}
 
+image="alpine/helm"
+repo="helm/helm"
+
+if [[ ${CI} == 'true' ]]; then
+  CURL="curl -sL -H \"Authorization: token ${API_TOKEN}\""
+else
+  CURL="curl -sL"
 fi
+
+latest=`${CURL} https://api.github.com/repos/${repo}/tags |jq -r ".[].name"|head -10|sed 's/^v//'`
+echo "Lastest releases are: ${latest}"
+
+for tag in ${latest}
+do
+  echo $tag
+  status=$(curl -sL https://hub.docker.com/v2/repositories/${image}/tags/${tag})
+  echo $status
+  if [[ "${status}" =~ "Not found" ]]; then
+    build ${tag}
+  fi
+done

--- a/build.sh
+++ b/build.sh
@@ -13,15 +13,14 @@ Usage() {
 }
 
 build() {
-  BUILD_TAG=$1
 
-  docker build --no-cache --build-arg VERSION=${BUILD_TAG} -t ${image}:${BUILD_TAG} .
+  docker build --no-cache --build-arg VERSION=${tag} -t ${image}:${tag} .
 
   # test
-  version=`docker run -ti --rm ${image}:${BUILD_TAG} version --client`
+  version=$(docker run -ti --rm ${image}:${tag} version --client)
   #Client: &version.Version{SemVer:"v2.9.0-rc2", GitCommit:"08db2d0181f4ce394513c32ba1aee7ffc6bc3326", GitTreeState:"clean"}
   version=$(echo ${version}| awk -F \" '{print $2}')
-  if [ "${version}" == "v${BUILD_TEST}" ]; then
+  if [ "${version}" == "v${tag}" ]; then
     echo "matched"
   else
     echo "unmatched"
@@ -30,7 +29,7 @@ build() {
 
   if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    docker push ${image}:${BUILD_TAG}
+    docker push ${image}:${tag}
   fi
 }
 
@@ -51,6 +50,6 @@ do
   status=$(curl -sL https://hub.docker.com/v2/repositories/${image}/tags/${tag})
   echo $status
   if [[ "${status}" =~ "Not found" ]]; then
-    build ${tag}
+    build
   fi
 done

--- a/build.sh
+++ b/build.sh
@@ -38,12 +38,11 @@ image="alpine/helm"
 repo="helm/helm"
 
 if [[ ${CI} == 'true' ]]; then
-  CURL="curl -sL -H \"Authorization: token ${API_TOKEN}\""
+  latest=`curl -sL -H "Authorization: token ${API_TOKEN}"  https://api.github.com/repos/${repo}/tags |jq -r ".[].name"|sort -Vr|head -10|sed 's/^v//'`
 else
-  CURL="curl -sL"
+  latest=`curl -sL https://api.github.com/repos/${repo}/tags |jq -r ".[].name"|sort -Vr|head -10|sed 's/^v//'`
 fi
 
-latest=`${CURL} https://api.github.com/repos/${repo}/tags |jq -r ".[].name"|head -10|sed 's/^v//'`
 echo "Lastest releases are: ${latest}"
 
 for tag in ${latest}

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ build() {
   docker build --no-cache --build-arg VERSION=${BUILD_TAG} -t ${image}:${BUILD_TAG} .
 
   # test
-  version=$(docker run -ti --rm ${image}:${BUILD_TAG} version )
+  version=`docker run -ti --rm ${image}:${BUILD_TAG} version --client`
   #Client: &version.Version{SemVer:"v2.9.0-rc2", GitCommit:"08db2d0181f4ce394513c32ba1aee7ffc6bc3326", GitTreeState:"clean"}
   version=$(echo ${version}| awk -F \" '{print $2}')
   if [ "${version}" == "v${BUILD_TEST}" ]; then


### PR DESCRIPTION
fix the bug #6 that can't build any new 2.4.x images if newer versions 3.x were created.

The new way to detect the versions will be 

1) find out the latest 10 versions
2) if any versions are not built, will built it. 

With this way, we can build for both 2.x and 3.x versions

But we lost the chance to update tag `latest`. I will think about it when have time.