### PR TITLE
Feature/8 - bug fix to deal with latest release tag

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,3 +53,17 @@ do
     build
   fi
 done
+
+
+# deal with latest release
+# <html><body>You are being <a href="https://github.com/helm/helm/releases/tag/v2.14.3">redirected</a>.</body></html>
+latest=$(curl -s https://github.com/${repo}/releases/latest)
+latest=$(echo $latest\" |grep -oP '(?<=tag\/)v[0-9][^"]*')
+echo $latest
+
+if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+  docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  docker pull ${image}:${latest}
+  docker tag ${image}:${latest} ${image}:latest
+  docker push ${image}:latest
+fi

--- a/build.sh
+++ b/build.sh
@@ -58,7 +58,7 @@ done
 # deal with latest release
 # <html><body>You are being <a href="https://github.com/helm/helm/releases/tag/v2.14.3">redirected</a>.</body></html>
 latest=$(curl -s https://github.com/${repo}/releases/latest)
-latest=$(echo $latest\" |grep -oP '(?<=tag\/)v[0-9][^"]*')
+latest=$(echo $latest\" |grep -oP '(?<=tag\/v)[0-9][^"]*')
 echo $latest
 
 if [[ "$TRAVIS_BRANCH" == "master" ]]; then


### PR DESCRIPTION
Add extra steps to deal with latest release tag.

The latest release is not always the latest version, so I have to check every time, pull that version and tag as `latest`