### PR TITLE
Helm3+ build support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,11 @@ build() {
   # run test
   version=$(docker run -ti --rm ${image}:${tag} version --client)
   #Client: &version.Version{SemVer:"v2.9.0-rc2", GitCommit:"08db2d0181f4ce394513c32ba1aee7ffc6bc3326", GitTreeState:"clean"}
+  if [[ "${version}" == *"Error: unknown flag: --client"* ]]; then
+    echo "Detected Helm3+"
+    version=$(docker run -ti --rm ${image}:${tag} version)
+    #version.BuildInfo{Version:"v3.0.0-beta.2", GitCommit:"26c7338408f8db593f93cd7c963ad56f67f662d4", GitTreeState:"clean", GoVersion:"go1.12.9"}
+  fi
   version=$(echo ${version}| awk -F \" '{print $2}')
   if [ "${version}" == "v${tag}" ]; then
     echo "matched"


### PR DESCRIPTION
"--client" has been removed from Helm3+ since Tiller has been removed.