### PR TITLE
Add -v ~/.config/helm:/root/.config/helm to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Auto-trigger docker build for [kubernetes helm](https://github.com/kubernetes/he
 
 The latest docker tag is the latest release verison (https://github.com/helm/helm/releases/latest)
 
-Please avoid to use `latest` tag for any production deployment. Tag with right version is the proper way, such as `alpine/helm:2.14.0`
+Please avoid to use `latest` tag for any production deployment. Tag with right version is the proper way, such as `alpine/helm:3.1.1`
 
 ### Github Repo
 
@@ -25,17 +25,25 @@ https://hub.docker.com/r/alpine/helm/tags/
 # Usage
 
     # must mount the local folder to /apps in container.
-    docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm alpine/helm
+    docker run -ti --rm -v $(pwd):/apps \
+        -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm -v ~/.config/helm:/root/.config/helm \
+        alpine/helm
 
     # Run helm with special version. The tag is helm's version
-    docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm alpine/helm:2.12.1
+    docker run -ti --rm -v $(pwd):/apps \
+        -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm -v ~/.config/helm:/root/.config/helm \
+        alpine/helm:3.1.1
 
     # run container as command
-    alias helm="docker run -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm alpine/helm"
+    alias helm="docker run -ti --rm -v $(pwd):/apps \
+        -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm -v ~/.config/helm:/root/.config/helm \
+        alpine/helm"
     helm --help
     
     # example in ~/.bash_profile
-    alias helm='docker run -e KUBECONFIG="/root/.kube/config:/root/.kube/some-other-context.yaml" -ti --rm -v $(pwd):/apps -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm alpine/helm'
+    alias helm='docker run -e KUBECONFIG="/root/.kube/config:/root/.kube/some-other-context.yaml" -ti --rm -v $(pwd):/apps \
+        -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm -v ~/.config/helm:/root/.config/helm \
+        alpine/helm'
 
 # Why we need it
 

--- a/build.sh
+++ b/build.sh
@@ -61,7 +61,7 @@ latest=$(curl -s https://github.com/${repo}/releases)
 latest=$(echo $latest\" |grep -oP '(?<=tag\/v)[0-9][^"-]*'|sort -Vr|head -1)
 echo $latest
 
-if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == false ]]; then
   docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   docker pull ${image}:${latest}
   docker tag ${image}:${latest} ${image}:latest


### PR DESCRIPTION
In Helm 3, repositories added using "helm repo add" will be stored in ~/.config/helm, so we need to store that as a volume in order for the repositories to be persistent between calls to "docker run alpine/helm".