### PR TITLE
Add -v ~/.cache/helm:/root/.cache/helm to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,22 +27,26 @@ https://hub.docker.com/r/alpine/helm/tags/
     # must mount the local folder to /apps in container.
     docker run -ti --rm -v $(pwd):/apps \
         -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm -v ~/.config/helm:/root/.config/helm \
+        -v ~/.cache/helm:/root/.cache/helm \
         alpine/helm
 
     # Run helm with special version. The tag is helm's version
     docker run -ti --rm -v $(pwd):/apps \
         -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm -v ~/.config/helm:/root/.config/helm \
+        -v ~/.cache/helm:/root/.cache/helm \
         alpine/helm:3.1.1
 
     # run container as command
     alias helm="docker run -ti --rm -v $(pwd):/apps \
         -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm -v ~/.config/helm:/root/.config/helm \
+        -v ~/.cache/helm:/root/.cache/helm \
         alpine/helm"
     helm --help
     
     # example in ~/.bash_profile
     alias helm='docker run -e KUBECONFIG="/root/.kube/config:/root/.kube/some-other-context.yaml" -ti --rm -v $(pwd):/apps \
         -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm -v ~/.config/helm:/root/.config/helm \
+        -v ~/.cache/helm:/root/.cache/helm \
         alpine/helm'
 
 # Why we need it


### PR DESCRIPTION
In addition to .config/helm, also share .cache/helm because that is where individual charts are stored from the repository.

This is a follow-up to #17, already merged. Both changes are necessary for Helm repositories to work correctly.