### PR TITLE
Adding power(ppc64le) architecture support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,19 @@ sudo: required
 services:
   - docker
 
-script:
-  - bash ./build.sh
+jobs:
+  include:
+    - stage: build amd64
+      script: 
+      - bash ./build.sh
+    - stage: build ppc64le
+      arch: ppc64le
+      before_script:
+      - sudo apt-get -qq update
+      - sudo apt-get -y install jq
+      script:
+      - bash ./build.sh
+    - stage: make multi-arch images
+      script:
+      - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./multiarch-image.sh; fi'
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
 FROM alpine:3
 
-# variable "VERSION" must be passed as docker environment variables during the image build
-# docker build --no-cache --build-arg VERSION=2.12.0 -t alpine/helm:2.12.0 .
+# variable "VERSION" & "ARCH" must be passed as docker environment variables during the image build
+# docker build --no-cache --build-arg VERSION=2.12.0 ARCH=amd64 -t alpine/helm:2.12.0 .
 
 ARG VERSION
+ARG ARCH
 
 # ENV BASE_URL="https://storage.googleapis.com/kubernetes-helm"
 ENV BASE_URL="https://get.helm.sh"
-ENV TAR_FILE="helm-v${VERSION}-linux-amd64.tar.gz"
+ENV TAR_FILE="helm-v${VERSION}-linux-${ARCH}.tar.gz"
 
 RUN apk add --update --no-cache curl ca-certificates && \
     curl -L ${BASE_URL}/${TAR_FILE} |tar xvz && \
-    mv linux-amd64/helm /usr/bin/helm && \
+    mv linux-${ARCH}/helm /usr/bin/helm && \
     chmod +x /usr/bin/helm && \
-    rm -rf linux-amd64 && \
+    rm -rf linux-${ARCH} && \
     apk del curl && \
     rm -f /var/cache/apk/*
 

--- a/build.sh
+++ b/build.sh
@@ -9,16 +9,18 @@
 # set -ex
 
 build() {
-
-  echo "Found new version, building the image ${image}:${tag}"
-  docker build --no-cache --build-arg VERSION=${tag} -t ${image}:${tag} .
+  
+  
+  if [[ ${ARCH} == 'x86_64' ]]; then ARCH=amd64; fi
+  echo "Found new version, building the image ${image}:${tag}-${ARCH}"
+  docker build --no-cache --build-arg VERSION=${tag} --build-arg ARCH=${ARCH} -t ${image}:${tag}-${ARCH} .
 
   # run test
-  version=$(docker run -ti --rm ${image}:${tag} version --client)
+  version=$(docker run --rm ${image}:${tag}-${ARCH} version --client)
   #Client: &version.Version{SemVer:"v2.9.0-rc2", GitCommit:"08db2d0181f4ce394513c32ba1aee7ffc6bc3326", GitTreeState:"clean"}
   if [[ "${version}" == *"Error: unknown flag: --client"* ]]; then
     echo "Detected Helm3+"
-    version=$(docker run -ti --rm ${image}:${tag} version)
+    version=$(docker run --rm ${image}:${tag}-${ARCH} version)
     #version.BuildInfo{Version:"v3.0.0-beta.2", GitCommit:"26c7338408f8db593f93cd7c963ad56f67f662d4", GitTreeState:"clean", GoVersion:"go1.12.9"}
   fi
   version=$(echo ${version}| awk -F \" '{print $2}')
@@ -31,39 +33,21 @@ build() {
 
   if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    docker push ${image}:${tag}
+    docker push ${image}:${tag}-${ARCH}
   fi
 }
 
 image="alpine/helm"
 repo="helm/helm"
+ARCH=$(uname -m)
 
-if [[ ${CI} == 'true' ]]; then
-  latest=`curl -sL -H "Authorization: token ${API_TOKEN}"  https://api.github.com/repos/${repo}/tags |jq -r ".[].name"|sort -Vr|sed 's/^v//'`
-else
-  latest=`curl -sL https://api.github.com/repos/${repo}/tags |jq -r ".[].name"|sort -Vr|sed 's/^v//'`
-fi
-
+latest=`curl -sL https://api.github.com/repos/${repo}/tags |jq -r ".[].name"|sort -Vr|sed 's/^v//' | head -1`
 for tag in ${latest}
 do
   echo $tag
-  status=$(curl -sL https://hub.docker.com/v2/repositories/${image}/tags/${tag})
+  status=$(curl -sL https://hub.docker.com/v2/repositories/${image}/tags/${tag}-${ARCH})
   echo $status
   if [[ "${status}" =~ "not found" ]]; then
     build
   fi
 done
-
-echo "Update latest image with latest release"
-# output format for reference:
-# <html><body>You are being <a href="https://github.com/helm/helm/releases/tag/v2.14.3">redirected</a>.</body></html>
-latest=$(curl -s https://github.com/${repo}/releases)
-latest=$(echo $latest\" |grep -oP '(?<=tag\/v)[0-9][^"]*'|grep -v \-|sort -Vr|head -1)
-echo $latest
-
-if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == false ]]; then
-  docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  docker pull ${image}:${latest}
-  docker tag ${image}:${latest} ${image}:latest
-  docker push ${image}:latest
-fi

--- a/multiarch-image.sh
+++ b/multiarch-image.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Make sure you set secret enviroment variables in Travis CI
+# DOCKER_USERNAME
+# DOCKER_PASSWORD
+
+set -e
+
+function get_arch_images(){
+    image=$1; shift || fatal "usage error"
+    tag=$1; shift || fatal "usage error"
+	archs="amd64 ppc64le"
+    for arch in $archs; 
+	do
+        if [[ "$(docker pull ${image}:${tag}-${arch} >/dev/null 2>&1 ; echo $?)" == 0 ]]; then
+        	echo "${image}:${tag}-${arch} "
+	fi
+    done
+}
+
+image="alpine/helm"
+repo="helm/helm"
+
+if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == false ]]; then	
+	tags=`curl -sL https://api.github.com/repos/${repo}/tags |jq -r ".[].name"|sort -Vr|sed 's/^v//' | head -1` 
+	for tag in ${tags}
+		do
+			status=$(curl -sL https://hub.docker.com/v2/repositories/${image}/tags/${tag}-amd64)
+			echo $status
+			if [[ ! "${status}" =~ "not found" ]]; then
+				docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+				echo "Helm Version is $tag"
+				DOCKER_CLI_EXPERIMENTAL="enabled" docker manifest create ${image}:${tag} $(get_arch_images ${image} ${tag})
+				DOCKER_CLI_EXPERIMENTAL="enabled" docker manifest push --purge ${image}:${tag}
+				DOCKER_CLI_EXPERIMENTAL="enabled" docker manifest create ${image}:latest $(get_arch_images ${image} ${tag})
+				DOCKER_CLI_EXPERIMENTAL="enabled" docker manifest push --purge ${image}:latest
+			fi
+	 	done
+fi


### PR DESCRIPTION
This PR intends to add the support for POWER (ppc64le) architecture to the generated docker image. This change can be easily extended to other architectures as and when needed.

Travis log for this change is at -  https://travis-ci.org/github/bahetiamit/helm/builds/733226563 
Generated docker images at - https://hub.docker.com/repository/docker/bahetiamit/helm/tags?page=1 

Since the travis job is run as daily cron job on this repo, this change only builds the latest helm release as docker multiarch image to avoid building all the images for all the previous helm versions.