### PR TITLE
Create docker tag for minor and major aside patch tags

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,8 +30,13 @@ build() {
   fi
 
   if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+    semver=( ${tag//./ } )
     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
     docker push ${image}:${tag}
+    docker tag ${image}:${tag} ${image}:${semver[0]}.${semver[1]}
+    docker push ${image}:${semver[0]}.${semver[1]}
+    docker tag ${image}:${tag} ${image}:${semver[0]}
+    docker push ${image}:${semver[0]}
   fi
 }
 


### PR DESCRIPTION
When looking at the `alpine/docker` tags for `alpine/docker:3`, found that is is missing, this PR adds. So that we can just use `alpine/docker:3` and not have to worry about staying up to date.