### PR TITLE
Include Helm 2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,9 +39,9 @@ image="alpine/helm"
 repo="helm/helm"
 
 if [[ ${CI} == 'true' ]]; then
-  latest=`curl -sL -H "Authorization: token ${API_TOKEN}"  https://api.github.com/repos/${repo}/tags |jq -r ".[].name"|sort -Vr|sed 's/^v//'`
+  latest=`curl -sL -H "Authorization: token ${API_TOKEN}"  https://api.github.com/repos/${repo}/tags?per_page=100 |jq -r ".[].name"|sort -Vr|sed 's/^v//'`
 else
-  latest=`curl -sL https://api.github.com/repos/${repo}/tags |jq -r ".[].name"|sort -Vr|sed 's/^v//'`
+  latest=`curl -sL https://api.github.com/repos/${repo}/tags?per_page=100 |jq -r ".[].name"|sort -Vr|sed 's/^v//'`
 fi
 
 for tag in ${latest}


### PR DESCRIPTION
By increasing the number of tags returned from GitHub. This should cover all the last versions of Helm v2.

Closes https://github.com/alpine-docker/helm/issues/26.