### PR TITLE
Release docker image for arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
+dist: focal
 sudo: required
 
 services:
   - docker
+
+before_script:
+  - mkdir -p ~/.docker/cli-plugins
+  - wget -O - https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
+  - chmod a+x ~/.docker/cli-plugins/docker-buildx
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  - docker buildx create --use --name mybuilder
 
 script:
   - bash ./build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,17 @@ FROM alpine:3
 # docker build --no-cache --build-arg VERSION=2.12.0 -t alpine/helm:2.12.0 .
 
 ARG VERSION
+ARG TARGETARCH
 
 # ENV BASE_URL="https://storage.googleapis.com/kubernetes-helm"
 ENV BASE_URL="https://get.helm.sh"
-ENV TAR_FILE="helm-v${VERSION}-linux-amd64.tar.gz"
+ENV TAR_FILE="helm-v${VERSION}-linux-$TARGETARCH.tar.gz"
 
 RUN apk add --update --no-cache curl ca-certificates && \
     curl -L ${BASE_URL}/${TAR_FILE} |tar xvz && \
-    mv linux-amd64/helm /usr/bin/helm && \
+    mv linux-$TARGETARCH/helm /usr/bin/helm && \
     chmod +x /usr/bin/helm && \
-    rm -rf linux-amd64 && \
+    rm -rf linux-$TARGETARCH && \
     apk del curl && \
     rm -f /var/cache/apk/*
 

--- a/build.sh
+++ b/build.sh
@@ -11,27 +11,9 @@
 build() {
 
   echo "Found new version, building the image ${image}:${tag}"
-  docker build --no-cache --build-arg VERSION=${tag} -t ${image}:${tag} .
-
-  # run test
-  version=$(docker run -ti --rm ${image}:${tag} version --client)
-  #Client: &version.Version{SemVer:"v2.9.0-rc2", GitCommit:"08db2d0181f4ce394513c32ba1aee7ffc6bc3326", GitTreeState:"clean"}
-  if [[ "${version}" == *"Error: unknown flag: --client"* ]]; then
-    echo "Detected Helm3+"
-    version=$(docker run -ti --rm ${image}:${tag} version)
-    #version.BuildInfo{Version:"v3.0.0-beta.2", GitCommit:"26c7338408f8db593f93cd7c963ad56f67f662d4", GitTreeState:"clean", GoVersion:"go1.12.9"}
-  fi
-  version=$(echo ${version}| awk -F \" '{print $2}')
-  if [ "${version}" == "v${tag}" ]; then
-    echo "matched"
-  else
-    echo "unmatched"
-    exit
-  fi
-
   if [[ "$TRAVIS_BRANCH" == "master" ]]; then
     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    docker push ${image}:${tag}
+    docker buildx build --platform linux/amd64,linux/arm64 --build-arg VERSION=${tag} -t ${image}:${tag} --push .
   fi
 }
 
@@ -63,7 +45,5 @@ echo $latest
 
 if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == false ]]; then
   docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  docker pull ${image}:${latest}
-  docker tag ${image}:${latest} ${image}:latest
-  docker push ${image}:latest
+  docker buildx build --platform linux/amd64,linux/arm64 --build-arg VERSION=${latest} -t ${image}:latest --push .
 fi


### PR DESCRIPTION
Resolves #31.

The following files have been modified:

- Added a new build argument TARGETARCH in the **Dockerfile** which will decide which architecture binary to install.

- In **.travis.yml** added “dist:focal” in order to use buildx and installed buildx binary and created a new builder and switched to it.

- I have used buildx to build and push the image for both platforms in the **build.sh** file.
