### PR TITLE
Update wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG VERSION
 ENV BASE_URL="https://get.helm.sh"
 ENV TAR_FILE="helm-v${VERSION}-linux-amd64.tar.gz"
 
-RUN apk add --update --no-cache curl ca-certificates && \
+RUN apk add --update --no-cache curl ca-certificates wget && \
     curl -L ${BASE_URL}/${TAR_FILE} |tar xvz && \
     mv linux-amd64/helm /usr/bin/helm && \
     chmod +x /usr/bin/helm && \


### PR DESCRIPTION
Helm plugin install uses wget. For ppl behind a proxy running docker build --build-arg 'http_proxy=proxy-se-uan.ddc.teliasonera.net:8080' --build-arg 'https_proxy=proxy-se-uan.ddc.teliasonera.net:8080' . results in bad request. Updating wget helps solve this issue