### PR TITLE
Feature/multi arch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,19 @@
-sudo: required
+language: bash
 
-services:
-  - docker
+dist: bionic
+
+env:
+  - DOCKER_CLI_EXPERIMENTAL=enabled
+
+before_install:
+  - sudo rm -rf /var/lib/apt/lists/*
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - lsb_release -cs
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 script:
-  - bash ./build.sh
+  - docker version
+  - make build-push

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+BUILDX_VER=v0.5.1
+
+install:
+	mkdir -vp ~/.docker/cli-plugins/ ~/dockercache
+	curl --silent -L "https://github.com/docker/buildx/releases/download/${BUILDX_VER}/buildx-${BUILDX_VER}.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+	chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+build-push:
+	bash ./build.sh

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ Please avoid to use `latest` tag for any production deployment. Tag with right v
 
 If you need run `kubectl` with `helm` together, please use another image [alpine/k8s](https://github.com/alpine-docker/k8s)
 
+## Additional notes about multi-arch images
+
+This feature was added on 23th May 2021.
+
+1. Version 3.5.4 and 3.6.0-rc.1 are manually pushed by me with multi-arch image supported
+2. Older version will be not updated as multi-arch images
+3. Newer vesions from now on will be multi-arch images (`--platform linux/amd64,linux/arm/v7,linux/arm64/v8,linux/arm/v6,linux/ppc64le,linux/s390x`)
+4. tag `latest` doesn't suppoort multi-arch yet, because I can't find a good way to tag it only without rebuild it.
+5. I don't support other architectures, excpet `amd64`, because I have no other environment to do that. If you have any issues with other arch, you need raise PR to fix it.
+6. There would be no different for `docker pull` , `docker run` command with other arch, you can run it as normal. For example, if you need pull image from arm (such as new Mac M1 chip), you can run normally `docker pull alpine/helm:3.5.4` to get the image directly.
+
 ### Github Repo
 
 https://github.com/alpine-docker/helm

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This feature was added on 23th May 2021.
 2. Older version will be not updated as multi-arch images
 3. Newer vesions from now on will be multi-arch images (`--platform linux/amd64,linux/arm/v7,linux/arm64/v8,linux/arm/v6,linux/ppc64le,linux/s390x`)
 4. tag `latest` doesn't suppoort multi-arch yet, because I can't find a good way to tag it only without rebuild it.
-5. I don't support other architectures, excpet `amd64`, because I have no other environment to do that. If you have any issues with other arch, you need raise PR to fix it.
+5. I don't support other architectures, except `amd64`, because I have no other environment to do that. If you have any issues with other arch, you need raise PR to fix it.
 6. There would be no different for `docker pull` , `docker run` command with other arch, you can run it as normal. For example, if you need pull image from arm (such as new Mac M1 chip), you can run normally `docker pull alpine/helm:3.5.4` to get the image directly.
 
 ### Github Repo

--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,7 @@ build() {
     docker buildx create --use
     docker buildx build --no-cache --push \
 		--build-arg VERSION=${tag} \
-		--platform linux/arm/v7,linux/arm64/v8,linux/amd64 \
+		--platform linux/amd64,linux/arm/v7,linux/arm64/v8,linux/arm/v6,linux/ppc64le,linux/s390x \
 		-t ${image}:${tag} .
   fi
 }

--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,7 @@ do
   echo $tag
   status=$(curl -sL https://hub.docker.com/v2/repositories/${image}/tags/${tag})
   echo $status
-  if [[ ( "${status}" =~ "not found" ) || ( ${REBUILD} == "true" ) ]]; then
+  if [[ "${status}" =~ "not found" ]]; then
     build
   fi
 done


### PR DESCRIPTION
1. Version `3.5.4` and `3.6.0-rc.1` are manually pushed by me with multi-arch image supported
2. Older version will be not updated as multi-arch images
3. Newer vesions from now on will be multi-arch images (`--platform linux/amd64,linux/arm/v7,linux/arm64/v8,linux/arm/v6,linux/ppc64le,linux/s390x`)
4. tag `latest` doesn't suppoort multi-arch yet, because I can't find a good way to tag it only without rebuild it.
5. I don't support other architectures, except `amd64`, because I have no other environment to do that. If you have any issues with other arch, you need raise PR to fix it.
6. There would be no different for `docker pull` , `docker run` command with other arch, you can run it as normal. For example, if you need pull image from arm (such as new Mac M1 chip), you can run normally `docker pull alpine/helm:3.5.4` to get the image directly.


![image](https://user-images.githubusercontent.com/8954908/119255418-15b26700-bbff-11eb-82dc-45226fd3f001.png)

close https://github.com/alpine-docker/helm/issues/31

Reference template

https://github.com/alpine-docker/multi-arch-docker-build-on-ci