### PR TITLE
add git to be able to install Helm plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN case `uname -m` in \
         s390x) ARCH=s390x; ;; \
         *) echo "un-supported arch, exit ..."; exit 1; ;; \
     esac && \
-    apk add --update --no-cache wget && \
+    apk add --update --no-cache wget git && \
     wget ${BASE_URL}/helm-v${VERSION}-linux-${ARCH}.tar.gz -O - | tar -xz && \
     mv linux-${ARCH}/helm /usr/bin/helm && \
     chmod +x /usr/bin/helm && \


### PR DESCRIPTION
In order to be able to install Helm plugins `git` is needed.

example: `helm plugin install https://github.com/chartmuseum/helm-push.git` fails with 

```
$ helm plugin install https://github.com/chartmuseum/helm-push.git
Error: git is not installed
```