### PR TITLE
chore: add OCI label indicating source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM alpine:3
 
 ARG VERSION
 
+LABEL org.opencontainers.image.source="https://github.com/alpine-docker/helm"
+
 # ENV BASE_URL="https://storage.googleapis.com/kubernetes-helm"
 ENV BASE_URL="https://get.helm.sh"
 


### PR DESCRIPTION
This label is documented as:

> **org.opencontainers.image.source** URL to get source code for building the image (string)

Source: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

This label can be used by tools to give a link back to this repository, e.g. [renovate](https://renovatebot.com/) will use this label when it creates pull request to update this docker image.