### PR TITLE
Install bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN case `uname -m` in \
         s390x) ARCH=s390x; ;; \
         *) echo "un-supported arch, exit ..."; exit 1; ;; \
     esac && \
-    apk add --update --no-cache wget git curl && \
+    apk add --update --no-cache wget git curl bash && \
     wget ${BASE_URL}/helm-v${VERSION}-linux-${ARCH}.tar.gz -O - | tar -xz && \
     mv linux-${ARCH}/helm /usr/bin/helm && \
     chmod +x /usr/bin/helm && \


### PR DESCRIPTION
Install bash in the container.

We use some more advanced scripting features in our pipeline that are not supported in `sh`. I would like to see `bash` included in this image. 