### PR TITLE
chore: add OCI image annotations to docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ FROM alpine:3
 
 ARG VERSION
 
+LABEL org.opencontainers.image.source=https://github.com/alpine-docker/helm
+LABEL org.opencontainers.image.documentation=https://hub.docker.com/r/alpine/helm
+LABEL org.opencontainers.image.version=$VERSION
+
 # ENV BASE_URL="https://storage.googleapis.com/kubernetes-helm"
 ENV BASE_URL="https://get.helm.sh"
 


### PR DESCRIPTION
Add [OCI image annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) to the image containing the version URLs for the documentation and source.

These annotations are useful for people to manually use as well as for use by tools. For example, [Snyk uses them in its UI](https://snyk.io/blog/how-and-when-to-use-docker-labels-oci-container-annotations/) and [Renovate uses them to find release notes](https://github.com/renovatebot/renovate/blob/34.115.1/lib/modules/datasource/docker/readme.md).