### PR TITLE
Fixed alias example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ https://hub.docker.com/r/alpine/helm/tags/
         alpine/helm:3.1.1
 
     # run container as command
-    alias helm="docker run -ti --rm -v $(pwd):/apps -w /apps \
+    alias helm='docker run -ti --rm -v $(pwd):/apps -w /apps \
         -v ~/.kube:/root/.kube -v ~/.helm:/root/.helm -v ~/.config/helm:/root/.config/helm \
         -v ~/.cache/helm:/root/.cache/helm \
-        alpine/helm"
+        alpine/helm'
     helm --help
     
     # example in ~/.bash_profile


### PR DESCRIPTION
Changed quotes in this example from double to single.  Currently the $(pwd) expands out at definition time instead of run time.  This causes the home directory to always mount to the /apps directory instead of the current working director.  Which seemed like undesired behavior to me.