### PR TITLE
`apk add yq` for parsing Chart.yaml file before building helm pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN case `uname -m` in \
         s390x) ARCH=s390x; ;; \
         *) echo "un-supported arch, exit ..."; exit 1; ;; \
     esac && \
-    apk add --update --no-cache wget git curl bash && \
+    apk add --update --no-cache wget git curl bash yq && \
     wget ${BASE_URL}/helm-v${VERSION}-linux-${ARCH}.tar.gz -O - | tar -xz && \
     mv linux-${ARCH}/helm /usr/bin/helm && \
     chmod +x /usr/bin/helm && \


### PR DESCRIPTION
Can we please include `yq` tool for getting some values from Chart.yaml when making helm builds? There are `jq` and `yq` in https://github.com/alpine-docker/k8s/blob/master/Dockerfile but would be nice to have it in the slim version too.