### PR TITLE
feat: Add rollup tags

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,11 @@ build() {
       --build-arg VERSION=${tag} \
       -t ${image}:${tag} .
 
-  ./crane copy ${image}:${tag} ${image}:latest
+    minor=${tag%.*}
+    major=${tag%%.*}
+    for extraTag in ${minor} ${major} "latest"; do
+      ./crane copy ${image}:${tag} ${image}:${extraTag}
+    done
 
   fi
 }


### PR DESCRIPTION
Many images use "rollup" style tags to allow devs to stay current on a minor or major release line, while still avoiding the inherent problems of using `latest`. This PR provides that functionality for `alpine/helm`, so that, for example, when `v3.15.5` of the `helm` CLI is released, the following tags would be created:

```
* 3.15.5
* 3.15
* 3
* latest
```

When `3.15.6` is released, the last 3 tags would be updated. When `3.16.0` is released, `3` would be updated, but not `3.15`.

Thanks for your consideration.