### PR TITLE
Add missing output for check_tag job, fixes #67

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-
+    outputs:
+      build_required: ${{ steps.curl-version.outputs.build_required }}
     steps:
       # Step to fetch the latest version
       - name: Get latest version


### PR DESCRIPTION
As https://github.com/alpine-docker/helm/issues/67 describes, the "build_required" output is missing in the "check_tag" job.
I verified on my fork that the "build_and_push" job really starts when this is present.