### PR TITLE
Build from alpine:latest instead of edge, to avoid coreutils issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:latest
 
 # variable "VERSION" must be passed as docker environment variables during the image build
 # docker build --no-cache --build-arg VERSION=2.12.0 -t alpine/helm:2.12.0 .


### PR DESCRIPTION
If you apk add coreutils in current image built on top of edge, a bunch of symbol errors appears after.

This does not happen with alpine:latest.

Related github issue: https://github.com/alpine-docker/helm/issues/72